### PR TITLE
glt - Add UCSB Organization dropdown to navbar

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -75,6 +75,18 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                   </NavDropdown>
                 )
               }
+              {
+		hasRole(currentUser, "ROLE_USER") && (
+                  <NavDropdown title="UCSBOrganizations" id="appnavbar-ucsborganizations-dropdown" data-testid="appnavbar-ucsborganizations-dropdown" >
+		    <NavDropdown.Item as={Link} to="/UCSBOrganizations/list" data-testid="appnavbar-ucsborganizations-list">List</NavDropdown.Item>
+	              {
+	                hasRole(currentUser, "ROLE_ADMIN") && (
+		          <NavDropdown.Item as={Link} to="/UCSBOrganizations/create" data-testid="appnavbar-ucsborganizations-create">Create</NavDropdown.Item>
+	                )
+	              }
+		  </NavDropdown>
+		)
+	      }
             </Nav>
 
             <Nav className="ml-auto">

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -236,6 +236,31 @@ describe("AppNavbar tests", () => {
         await waitFor( () => expect(getByTestId(/appnavbar-dining-commons-list/)).toBeInTheDocument() );
 
     });
+
+    test("renders the UCSBOrganization menu correctly for an admin", async () => {
+
+        const currentUser = currentUserFixtures.adminUser;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-ucsborganizations-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-ucsborganizations-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId(/appnavbar-ucsborganizations-list/)).toBeInTheDocument() );
+	await waitFor( () => expect(getByTestId(/appnavbar-ucsborganizations-create/)).toBeInTheDocument() );
+
+    });
    
 });
 


### PR DESCRIPTION
In this PR we add a UCSB Organization dropdown to the navbar with clickable links to `/UCSBOrganizations/create` and `/UCSBOrganizations/list`.  We also added tests for the new entry in the menu.

Closes #29 