### PR TITLE
glt - Add UCSB Organization index stub

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,6 +16,8 @@ import UCSBDatesIndexPage from "main/pages/UCSBDates/UCSBDatesIndexPage";
 import UCSBDatesCreatePage from "main/pages/UCSBDates/UCSBDatesCreatePage";
 import UCSBDatesEditPage from "main/pages/UCSBDates/UCSBDatesEditPage";
 
+import UCSBOrganizationsIndexPage from "main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage";
+
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -61,7 +63,8 @@ function App() {
         {
           hasRole(currentUser, "ROLE_USER") && (
             <>
-              <Route exact path="/ucsbdates/list" element={<UCSBDatesIndexPage />} />
+		  <Route exact path="/ucsbdates/list" element={<UCSBDatesIndexPage />} />
+		  <Route exact path="/UCSBOrganizations/list" element={<UCSBOrganizationsIndexPage />} />
             </>
           )
         }

--- a/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.js
+++ b/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.js
@@ -1,22 +1,8 @@
 import React from 'react'
-import { useBackend } from 'main/utils/useBackend'; // use prefix indicates a React Hook
 
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
-import { useCurrentUser } from 'main/utils/currentUser' // use prefix indicates a React Hook
 
 export default function UCSBOrganizationsIndexPage() {
-
-  const currentUser = useCurrentUser();
-
-  const { data: dates, error: _error, status: _status } =
-    useBackend(
-      // Stryker disable next-line all : don't test internal caching of React Query
-      ["/api/UCSBOrganization/all"],
-            // Stryker disable next-line StringLiteral,ObjectLiteral : since "GET" is default, "" is an equivalent mutation
-            { method: "GET", url: "/api/UCSBOrganization/all" },
-      []
-    );
-
   return (
     <BasicLayout>
       <div className="pt-2">

--- a/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.js
+++ b/frontend/src/main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend'; // use prefix indicates a React Hook
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useCurrentUser } from 'main/utils/currentUser' // use prefix indicates a React Hook
+
+export default function UCSBOrganizationsIndexPage() {
+
+  const currentUser = useCurrentUser();
+
+  const { data: dates, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/UCSBOrganization/all"],
+            // Stryker disable next-line StringLiteral,ObjectLiteral : since "GET" is default, "" is an equivalent mutation
+            { method: "GET", url: "/api/UCSBOrganization/all" },
+      []
+    );
+
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>UCSBOrganizations</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/tests/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.test.js
@@ -1,0 +1,77 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import UCSBOrganizationsIndexPage from "main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage";
+
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("UCSBOrganizationsIndexPage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+
+    const testId = "UCSBOrganizationsIndexPage";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/UCSBOrganizations/list").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/UCSBOrganization/list").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBOrganizationsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+});
+
+

--- a/frontend/src/tests/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBOrganizations/UCSBOrganizationsIndexPage.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import UCSBOrganizationsIndexPage from "main/pages/UCSBOrganizations/UCSBOrganizationsIndexPage";
@@ -8,7 +8,6 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import mockConsole from "jest-mock-console";
 
 
 const mockToast = jest.fn();
@@ -24,8 +23,6 @@ jest.mock('react-toastify', () => {
 describe("UCSBOrganizationsIndexPage tests", () => {
 
     const axiosMock =new AxiosMockAdapter(axios);
-
-    const testId = "UCSBOrganizationsIndexPage";
 
     const setupUserOnly = () => {
         axiosMock.reset();


### PR DESCRIPTION
In this PR we create the route for `/UCSBOrganization/list` with a stub index. There are no tests yet.  I'll add them when I make the real index page.

Closes #30

Merge after #43