### PR TITLE
glt - fix UCSBOrganization update after delete

### DIFF
--- a/frontend/src/main/components/UCSBOrganizations/UCSBOrganizationsTable.js
+++ b/frontend/src/main/components/UCSBOrganizations/UCSBOrganizationsTable.js
@@ -12,7 +12,7 @@ export default function UCSBOrganizationsTable({ orgs, currentUser }) {
     const deleteMutation = useBackendMutation(
         cellToAxiosParamsDelete,
         { onSuccess: onDeleteSuccess },
-        ["/api/UCSBOrganizations/all"]
+        ["/api/UCSBOrganization/all"]
     );
     // Stryker enable all 
 


### PR DESCRIPTION
In this PR we fix the bug where the UCSBOrganization index page (specifically the table) does not update after a delete operation.